### PR TITLE
fixed import data auth button, input refocuses after failed biometrics

### DIFF
--- a/src/components/pinCodes/OnboardingPinCode/index.tsx
+++ b/src/components/pinCodes/OnboardingPinCode/index.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo} from 'react';
+import React, {RefObject, useCallback, useEffect, useMemo} from 'react';
 import {Animated, Keyboard, Platform, TextInput, TextInputProps, TouchableOpacity} from 'react-native';
 import {ONLY_ALLOW_NUMBERS_REGEX} from '../../../@config/constants';
 import {translate} from '../../../localization/Localization';
@@ -23,6 +23,7 @@ type Props = TextInputProps & {
   length?: number;
   secureCode?: boolean;
   validation?: ValidationConfig;
+  inputRef?: RefObject<TextInput>;
 };
 
 const failureAnimationConfig = {
@@ -31,9 +32,16 @@ const failureAnimationConfig = {
   colorShiftDuration: 100,
 };
 
-const OnboardingPinCode = ({pin, onPinChange, length = 4, secureCode = true, validation, ...textInputProps}: Props) => {
+const OnboardingPinCode = ({
+  pin,
+  onPinChange,
+  length = 4,
+  secureCode = true,
+  validation,
+  inputRef = React.useRef<TextInput | null>(null),
+  ...textInputProps
+}: Props) => {
   const {isValid, maxRetries, onMaxRetriesExceeded, hideKeyboardOnValidAndComplete = false, triggerValidation = 'onComplete'} = validation ?? {};
-  const inputRef = React.useRef<TextInput | null>(null);
   const [retriesLeft, setRetriesLeft] = React.useState(maxRetries ?? Infinity);
   const shakeAnimation = useMemo(() => new Animated.Value(0), []);
   const colorShiftAnimation = useMemo(() => new Animated.Value(0), []);

--- a/src/screens/Onboarding/EnableBiometricsScreen/use-biometrics.ts
+++ b/src/screens/Onboarding/EnableBiometricsScreen/use-biometrics.ts
@@ -41,7 +41,6 @@ export const useAuthEffect = (effect: (success: boolean) => void) => {
 
   useEffect(() => {
     if (biometricsEnabled) {
-      console.log('val', onboardingInstance.getSnapshot().value);
       prompt().then(effect);
     }
   }, []);

--- a/src/screens/Onboarding/EnableBiometricsScreen/use-biometrics.ts
+++ b/src/screens/Onboarding/EnableBiometricsScreen/use-biometrics.ts
@@ -41,7 +41,9 @@ export const useAuthEffect = (effect: (success: boolean) => void) => {
 
   useEffect(() => {
     if (biometricsEnabled) {
-      prompt().then(effect);
+      setTimeout(() => {
+        prompt().then(effect);
+      }, 1000);
     }
   }, []);
 };

--- a/src/screens/Onboarding/ImportDataAuthenticationScreen/index.tsx
+++ b/src/screens/Onboarding/ImportDataAuthenticationScreen/index.tsx
@@ -1,16 +1,17 @@
 import {fontColors} from '@sphereon/ui-components.core';
 import {PrimaryButton} from '@sphereon/ui-components.ssi-react-native';
-import {useContext, useMemo, useState} from 'react';
+import {useContext, useMemo, useRef, useState} from 'react';
+import {View} from 'react-native';
+import {TextInput} from 'react-native-gesture-handler';
+import Animated, {useAnimatedKeyboard, useAnimatedStyle} from 'react-native-reanimated';
+import {PIN_CODE_LENGTH} from '../../../@config/constants';
+import ScreenContainer from '../../../components/containers/ScreenContainer';
+import ScreenTitleAndDescription from '../../../components/containers/ScreenTitleAndDescription';
+import PinCode from '../../../components/pinCodes/OnboardingPinCode';
 import {translate} from '../../../localization/Localization';
 import {OnboardingContext} from '../../../navigation/machines/onboardingStateNavigation';
 import {OnboardingMachineEvents} from '../../../types/machines/onboarding';
-import PinCode from '../../../components/pinCodes/OnboardingPinCode';
-import {PIN_CODE_LENGTH} from '../../../@config/constants';
-import ScreenTitleAndDescription from '../../../components/containers/ScreenTitleAndDescription';
-import ScreenContainer from '../../../components/containers/ScreenContainer';
 import {useAuthEffect} from '../EnableBiometricsScreen/use-biometrics';
-import Animated, {useAnimatedKeyboard, useAnimatedStyle} from 'react-native-reanimated';
-import {View} from 'react-native';
 
 const ImportDataAuthenticationScreen = () => {
   const {onboardingInstance} = useContext(OnboardingContext);
@@ -19,13 +20,18 @@ const ImportDataAuthenticationScreen = () => {
   } = onboardingInstance.getSnapshot();
   const [pinCode, setPinCode] = useState('');
   const doPinsCompletelyMatch = useMemo(() => pinCode === pinCodeContext, [pinCode, pinCodeContext]);
+  const keyboard = useAnimatedKeyboard();
+  const pinInputRef = useRef<TextInput>(null);
 
   useAuthEffect((success: boolean) => {
-    if (!success) return;
+    if (!success) {
+      if (pinInputRef.current) {
+        pinInputRef.current.focus();
+      }
+      return;
+    }
     onboardingInstance.send(OnboardingMachineEvents.NEXT);
   });
-
-  const keyboard = useAnimatedKeyboard();
 
   const style = useAnimatedStyle(() => {
     return {
@@ -55,7 +61,7 @@ const ImportDataAuthenticationScreen = () => {
   return (
     <ScreenContainer disableKeyboardAvoidingView={true} footer={footer}>
       <ScreenTitleAndDescription title={translate('import_data_auth_title')} />
-      <PinCode pin={pinCode} onPinChange={setPinCode} length={PIN_CODE_LENGTH} validation={{isValid: doPinsCompletelyMatch}} />
+      <PinCode inputRef={pinInputRef} pin={pinCode} onPinChange={setPinCode} length={PIN_CODE_LENGTH} validation={{isValid: doPinsCompletelyMatch}} />
     </ScreenContainer>
   );
 };

--- a/src/screens/Onboarding/ImportDataAuthenticationScreen/index.tsx
+++ b/src/screens/Onboarding/ImportDataAuthenticationScreen/index.tsx
@@ -9,6 +9,8 @@ import {PIN_CODE_LENGTH} from '../../../@config/constants';
 import ScreenTitleAndDescription from '../../../components/containers/ScreenTitleAndDescription';
 import ScreenContainer from '../../../components/containers/ScreenContainer';
 import {useAuthEffect} from '../EnableBiometricsScreen/use-biometrics';
+import Animated, {useAnimatedKeyboard, useAnimatedStyle} from 'react-native-reanimated';
+import {View} from 'react-native';
 
 const ImportDataAuthenticationScreen = () => {
   const {onboardingInstance} = useContext(OnboardingContext);
@@ -23,19 +25,35 @@ const ImportDataAuthenticationScreen = () => {
     onboardingInstance.send(OnboardingMachineEvents.NEXT);
   });
 
+  const keyboard = useAnimatedKeyboard();
+
+  const style = useAnimatedStyle(() => {
+    return {
+      transform: [
+        {
+          translateY: -keyboard.height.value,
+        },
+      ],
+    };
+  });
+
   const footer = (
-    <PrimaryButton
-      style={{height: 42, width: 300}}
-      caption="Next"
-      backgroundColors={['#7276F7', '#7C40E8']}
-      captionColor={fontColors.light}
-      onPress={() => onboardingInstance.send(OnboardingMachineEvents.NEXT)}
-      disabled={!doPinsCompletelyMatch}
-    />
+    <View>
+      <Animated.View style={style}>
+        <PrimaryButton
+          style={{height: 42, width: 300}}
+          caption="Next"
+          backgroundColors={['#7276F7', '#7C40E8']}
+          captionColor={fontColors.light}
+          onPress={() => onboardingInstance.send(OnboardingMachineEvents.NEXT)}
+          disabled={!doPinsCompletelyMatch}
+        />
+      </Animated.View>
+    </View>
   );
 
   return (
-    <ScreenContainer footer={footer}>
+    <ScreenContainer disableKeyboardAvoidingView={true} footer={footer}>
       <ScreenTitleAndDescription title={translate('import_data_auth_title')} />
       <PinCode pin={pinCode} onPinChange={setPinCode} length={PIN_CODE_LENGTH} validation={{isValid: doPinsCompletelyMatch}} />
     </ScreenContainer>


### PR DESCRIPTION
- disabled keyboard avoiding view on import data auth, using reanimated
- minor biometrics auth delay added to PID auth step, maybe resolve keyboard issue
- fix: in ImportDataAuthenticationScreen, programatically refocus pincode textInput when biometrics is disabled
