### PR TITLE
feat/sprind 96 url support

### DIFF
--- a/src/@config/constants/index.ts
+++ b/src/@config/constants/index.ts
@@ -20,7 +20,7 @@ export const VERIFICATION_CODE_MAX_RETRIES = 3;
 export const PIN_CODE_LENGTH = 6;
 
 export const EMAIL_ADDRESS_VALIDATION_REGEX = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
-export const URL_VALIDATION_REGEX = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+export const URL_VALIDATION_REGEX = /^(https?:\/\/)?((([a-zA-Z\d]([a-zA-Z\d-]*[a-zA-Z\d])*)\.)+[a-zA-Z]{2,63})(\/[^\s]*)?$/;
 export const ONLY_ALLOW_NUMBERS_REGEX = /^\d+$/;
 // TODO probably not supporting all mime variants
 export const IS_IMAGE_URI_REGEX = /^data:image\/(png|jpg|jpeg|bmp|gif|webp);base64,/;

--- a/src/utils/TextUtils.tsx
+++ b/src/utils/TextUtils.tsx
@@ -32,8 +32,11 @@ export const checkAndAddHTTPPrefix = (url: string) => {
 };
 
 export function parseValidURL(url: string) {
-  const invalidProtocols = ['file://', 'ftp://', 'mailto:', 'tel:', 'data:', 'javascript:', 'ws://', 'wss://', 'sms:', 'irc://', 'sftp://', 'blob:'];
-  if (invalidProtocols.some(p => url.startsWith(p))) return false;
+  // since some values that aren't valid web url could
+  // pass the checks for URL lib, we also use a regex here
+  const reg = /^(https?:\/\/)?((([a-zA-Z\d]([a-zA-Z\d-]*[a-zA-Z\d])*)\.)+[a-zA-Z]{2,63})(\/[^\s]*)?$/;
+  const valid = reg.test(url);
+  if (!valid) return false;
   try {
     const formattedUrl = url.startsWith('http://') ? url : `http://${url}`;
     const parsedUrl = new URL(formattedUrl);

--- a/src/utils/TextUtils.tsx
+++ b/src/utils/TextUtils.tsx
@@ -34,8 +34,7 @@ export const checkAndAddHTTPPrefix = (url: string) => {
 export function parseValidURL(url: string) {
   // since some values that aren't valid web url could
   // pass the checks for URL lib, we also use a regex here
-  const reg = /^(https?:\/\/)?((([a-zA-Z\d]([a-zA-Z\d-]*[a-zA-Z\d])*)\.)+[a-zA-Z]{2,63})(\/[^\s]*)?$/;
-  const valid = reg.test(url);
+  const valid = URL_VALIDATION_REGEX.test(url);
   if (!valid) return false;
   try {
     const formattedUrl = url.startsWith('http://') ? url : `http://${url}`;


### PR DESCRIPTION
- added strict web-url-specifc regex to web url parsing
- updated url validation regex const, used const in parseValidURL
