### PR TITLE
bugfix/mwall 711 lock screen and biometrics

### DIFF
--- a/src/components/pinCodes/SSIPinCode/index.tsx
+++ b/src/components/pinCodes/SSIPinCode/index.tsx
@@ -23,6 +23,7 @@ interface IProps {
   errorMessage?: string;
   onMaxRetriesExceeded?: () => Promise<void>;
   onVerification: (value: string) => Promise<void>;
+  autoFocus?: boolean;
 }
 
 interface IState {
@@ -207,7 +208,7 @@ class SSIPinCode extends PureComponent<IProps, IState> {
             accessibilityHint={accessibilityHint}
             accessibilityRole={'text'}
             keyboardType={'number-pad'}
-            autoFocus
+            autoFocus={this.props.autoFocus}
             caretHidden
             maxLength={length}
             onKeyPress={this.onKeyPressInput}

--- a/src/handlers/LockingHandler/index.ts
+++ b/src/handlers/LockingHandler/index.ts
@@ -65,18 +65,40 @@ class LockingHandler {
       case PlatformsEnum.ANDROID:
       case PlatformsEnum.IOS: {
         const handleAppStateChange = async (nextAppState: string): Promise<void> => {
-          if (nextAppState === 'background') {
-            //FIXME: for now we are autolocking going into background, so that
-            //ios face id does not cause this handler to relock after login
-            if (this.isLockingRequiredForScreen()) {
-              this.lock();
+          if (nextAppState === 'background' || nextAppState === 'active') {
+            if (Platform.OS === PlatformsEnum.IOS) {
+              if (nextAppState === 'active') return;
+              if (nextAppState === 'background' && this.isInactive() && this.isLockingRequiredForScreen()) {
+                return this.lock();
+              }
             }
-            if (Platform.OS === PlatformsEnum.IOS && this.isLockingRequiredForScreen()) {
-              return this.checkInactive();
-            } else {
-              return this.checkInactive();
+
+            if (Platform.OS === PlatformsEnum.ANDROID) {
+              if (nextAppState === 'background') return;
+              if (nextAppState === 'active') return this.checkInactive();
             }
+            // if (Platform.OS === PlatformsEnum.IOS && this.isLockingRequiredForScreen()) {
+            //   return this.checkInactive();
+            // } else {
+            return this.checkInactive();
+            // }
+          } else if (this.isInactive()) {
+            return this.lock();
           }
+          this.touchLastInteraction();
+          this.isLocked = false;
+          // if (nextAppState === 'background') {
+          //   //FIXME: for now we are autolocking going into background, so that
+          //   //ios face id does not cause this handler to relock after login
+          //   if (this.isLockingRequiredForScreen()) {
+          //     this.lock();
+          //   }
+          //   if (Platform.OS === PlatformsEnum.IOS && this.isLockingRequiredForScreen()) {
+          //     return this.checkInactive();
+          //   } else {
+          //     return this.checkInactive();
+          //   }
+          // }
           this.touchLastInteraction();
           this.isLocked = false;
         };

--- a/src/handlers/LockingHandler/index.ts
+++ b/src/handlers/LockingHandler/index.ts
@@ -66,39 +66,14 @@ class LockingHandler {
       case PlatformsEnum.IOS: {
         const handleAppStateChange = async (nextAppState: string): Promise<void> => {
           if (nextAppState === 'background' || nextAppState === 'active') {
-            if (Platform.OS === PlatformsEnum.IOS) {
-              if (nextAppState === 'active') return;
-              if (nextAppState === 'background' && this.isInactive() && this.isLockingRequiredForScreen()) {
-                return this.lock();
-              }
+            if (Platform.OS === PlatformsEnum.IOS && this.isLockingRequiredForScreen()) {
+              return this.checkInactive();
+            } else {
+              return this.checkInactive();
             }
-
-            if (Platform.OS === PlatformsEnum.ANDROID) {
-              if (nextAppState === 'background') return;
-              if (nextAppState === 'active') return this.checkInactive();
-            }
-            // if (Platform.OS === PlatformsEnum.IOS && this.isLockingRequiredForScreen()) {
-            //   return this.checkInactive();
-            // } else {
-            return this.checkInactive();
-            // }
           } else if (this.isInactive()) {
             return this.lock();
           }
-          this.touchLastInteraction();
-          this.isLocked = false;
-          // if (nextAppState === 'background') {
-          //   //FIXME: for now we are autolocking going into background, so that
-          //   //ios face id does not cause this handler to relock after login
-          //   if (this.isLockingRequiredForScreen()) {
-          //     this.lock();
-          //   }
-          //   if (Platform.OS === PlatformsEnum.IOS && this.isLockingRequiredForScreen()) {
-          //     return this.checkInactive();
-          //   } else {
-          //     return this.checkInactive();
-          //   }
-          // }
           this.touchLastInteraction();
           this.isLocked = false;
         };

--- a/src/hooks/use-biometrics.ts
+++ b/src/hooks/use-biometrics.ts
@@ -29,16 +29,12 @@ export const useBiometricsEnabledContext = () => {
 
 export const useBiometrics = () => {
   const authenticateBiometrically = async () => {
-    console.log('in biometrics prompt');
     try {
       const strongBiometricsSupported = await getStrongBiometricsSupport();
-      console.log('check strong biometrics');
       if (!strongBiometricsSupported) {
-        console.log('strong bio not found. returning false....');
         return false;
       }
 
-      console.log('strong bio found. prompting user...');
       const result = await Auth.authenticateAsync({
         promptMessage: 'Authenticate',
         cancelLabel: 'Cancel',
@@ -46,8 +42,6 @@ export const useBiometrics = () => {
         fallbackLabel: 'Try again later',
         biometricsSecurityLevel: 'strong',
       });
-
-      console.log('user prompted. returning ....');
 
       return result.success;
     } catch (error) {
@@ -69,22 +63,6 @@ type UseAuthEffectOptions = {
   promptDelay?: number;
 };
 type AuthEffectCallback = ((success: boolean) => void) | ((success: boolean) => Promise<void>);
-export const useAuthEffect = (effect: AuthEffectCallback) => {
-  const biometricsEnabled = useBiometricsEnabledContext();
-
-  const {prompt} = useBiometrics();
-
-  useEffect(() => {
-    console.log('in useEffect');
-    if (biometricsEnabled) {
-      console.log('found bio enabled. prompting....');
-      prompt().then(async (result: boolean) => {
-        await effect(result);
-      });
-    }
-  }, []);
-};
-
 export const useAuthFocusEffect = (effect: AuthEffectCallback) => {
   const navigation = useNavigation();
   const biometricsEnabled = useBiometricsEnabledContext();
@@ -92,11 +70,8 @@ export const useAuthFocusEffect = (effect: AuthEffectCallback) => {
   const {prompt} = useBiometrics();
 
   useEffect(() => {
-    console.log('in useEffect');
     const handleFocus = () => {
-      console.log('running listener');
       if (biometricsEnabled) {
-        console.log('found biometrics enabled');
         prompt().then((result: boolean) => {
           void effect(result);
         });
@@ -105,9 +80,7 @@ export const useAuthFocusEffect = (effect: AuthEffectCallback) => {
     navigation.addListener('focus', handleFocus);
 
     return () => {
-      console.log('unmounting');
       navigation.removeListener('focus', handleFocus);
-      // removeListener();
     };
   }, []);
 };
@@ -120,7 +93,7 @@ const isHardwareSupported = (hasHardware: boolean, supported: Auth.Authenticatio
   return hasHardware && (hasTouch || hasFacial);
 };
 
-type UseHasStringBiometricsOptions = {
+type UseHasStrongBiometricsOptions = {
   onBiometricsConfirmed?: (isSecure: boolean) => void;
 };
 
@@ -150,7 +123,7 @@ const getSupportedHardwareContext = async () => {
   };
 };
 
-export const useHasStrongBiometrics = (options: UseHasStringBiometricsOptions = {}) => {
+export const useHasStrongBiometrics = (options: UseHasStrongBiometricsOptions = {}) => {
   const {onBiometricsConfirmed} = options;
   const [hasSupportedHardware, setHasSupportedHardware] = useState(false);
   const [isSecure, setIsSecure] = useState(false);

--- a/src/hooks/use-biometrics.ts
+++ b/src/hooks/use-biometrics.ts
@@ -6,6 +6,7 @@ import {IUserState} from '../types/store/user.types';
 import {useDispatch, useSelector} from 'react-redux';
 import {RootState} from '../types';
 import {setBiometrics} from '../store/actions/user.actions';
+import {useNavigation} from '@react-navigation/native';
 
 export const useBiometricsEnabledContext = () => {
   const {onboardingInstance} = useContext(OnboardingContext);
@@ -28,12 +29,16 @@ export const useBiometricsEnabledContext = () => {
 
 export const useBiometrics = () => {
   const authenticateBiometrically = async () => {
+    console.log('in biometrics prompt');
     try {
       const strongBiometricsSupported = await getStrongBiometricsSupport();
+      console.log('check strong biometrics');
       if (!strongBiometricsSupported) {
+        console.log('strong bio not found. returning false....');
         return false;
       }
 
+      console.log('strong bio found. prompting user...');
       const result = await Auth.authenticateAsync({
         promptMessage: 'Authenticate',
         cancelLabel: 'Cancel',
@@ -41,6 +46,8 @@ export const useBiometrics = () => {
         fallbackLabel: 'Try again later',
         biometricsSecurityLevel: 'strong',
       });
+
+      console.log('user prompted. returning ....');
 
       return result.success;
     } catch (error) {
@@ -68,11 +75,40 @@ export const useAuthEffect = (effect: AuthEffectCallback) => {
   const {prompt} = useBiometrics();
 
   useEffect(() => {
+    console.log('in useEffect');
     if (biometricsEnabled) {
+      console.log('found bio enabled. prompting....');
       prompt().then(async (result: boolean) => {
         await effect(result);
       });
     }
+  }, []);
+};
+
+export const useAuthFocusEffect = (effect: AuthEffectCallback) => {
+  const navigation = useNavigation();
+  const biometricsEnabled = useBiometricsEnabledContext();
+
+  const {prompt} = useBiometrics();
+
+  useEffect(() => {
+    console.log('in useEffect');
+    const handleFocus = () => {
+      console.log('running listener');
+      if (biometricsEnabled) {
+        console.log('found biometrics enabled');
+        prompt().then((result: boolean) => {
+          void effect(result);
+        });
+      }
+    };
+    navigation.addListener('focus', handleFocus);
+
+    return () => {
+      console.log('unmounting');
+      navigation.removeListener('focus', handleFocus);
+      // removeListener();
+    };
   }, []);
 };
 

--- a/src/hooks/use-biometrics.ts
+++ b/src/hooks/use-biometrics.ts
@@ -83,6 +83,11 @@ export const useAuthFocusEffect = (effect: AuthEffectCallback) => {
       navigation.removeListener('focus', handleFocus);
     };
   }, []);
+
+  return {
+    prompt,
+    biometricsEnabled,
+  };
 };
 
 const isHardwareSupported = (hasHardware: boolean, supported: Auth.AuthenticationType[]) => {

--- a/src/screens/Onboarding/EnableBiometricsScreen/index.tsx
+++ b/src/screens/Onboarding/EnableBiometricsScreen/index.tsx
@@ -42,13 +42,11 @@ const Footnote = styled.Text`
 
 const EnableBiometricsScreen = () => {
   const {onboardingInstance} = useContext(OnboardingContext);
-  console.log('enabled?', onboardingInstance.getSnapshot().context.biometricsEnabled);
   const {prompt} = useBiometrics();
 
   const handleAuth = async () => {
     const success = await prompt();
     if (success) onboardingInstance.send(OnboardingMachineEvents.NEXT);
-    if (!success) alert('Strong biometrics not enabled or biometrics not enrolled');
   };
   const footer = (
     <Footer>

--- a/src/screens/Onboarding/ImportDataAuthenticationScreen/index.tsx
+++ b/src/screens/Onboarding/ImportDataAuthenticationScreen/index.tsx
@@ -8,7 +8,7 @@ import SSICloseIcon from '../../../components/assets/icons/SSICloseIcon';
 import ScreenContainer from '../../../components/containers/ScreenContainer';
 import ScreenTitleAndDescription from '../../../components/containers/ScreenTitleAndDescription';
 import PinCode from '../../../components/pinCodes/OnboardingPinCode';
-import {useAuthEffect, useBiometricsEnabledContext} from '../../../hooks/use-biometrics';
+import {useAuthEffect, useAuthFocusEffect, useBiometricsEnabledContext} from '../../../hooks/use-biometrics';
 import {translate} from '../../../localization/Localization';
 import {OnboardingContext} from '../../../navigation/machines/onboardingStateNavigation';
 import {storageGetPin} from '../../../services/storageService';
@@ -38,7 +38,7 @@ const ImportDataAuthenticationScreen = (props?: any) => {
 
   const [failed, setFailed] = useState(false);
 
-  useAuthEffect((success: boolean) => {
+  useAuthFocusEffect((success: boolean) => {
     if (!success) {
       if (pinInputRef.current) {
         pinInputRef.current.focus();

--- a/src/screens/SSILockScreen/index.tsx
+++ b/src/screens/SSILockScreen/index.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../styles/components';
 import {ScreenRoutesEnum, StackParamList} from '../../types';
 import {useAuthFocusEffect} from '../../hooks/use-biometrics';
-import LockingHandler from 'src/handlers/LockingHandler';
 
 type Props = NativeStackScreenProps<StackParamList, ScreenRoutesEnum.LOCK>;
 
@@ -26,7 +25,7 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
     });
   }, []);
 
-  useAuthFocusEffect(async (success: boolean) => {
+  const {biometricsEnabled, prompt} = useAuthFocusEffect(async (success: boolean) => {
     if (success) {
       const {onAuthenticate} = props.route.params;
       await onAuthenticate();
@@ -57,6 +56,7 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
           accessibilityHint={translate('pin_code_accessibility_hint')}
           errorMessage={translate('pin_code_invalid_code_message')}
           onVerification={onVerification}
+          autoFocus={!biometricsEnabled}
         />
       </PinCodeContainer>
       {/*<BadgeButton*/}

--- a/src/screens/SSILockScreen/index.tsx
+++ b/src/screens/SSILockScreen/index.tsx
@@ -6,17 +6,13 @@ import SSIPinCode from '../../components/pinCodes/SSIPinCode';
 import {storageGetPin} from '../../services/storageService';
 import {translate} from '../../localization/Localization';
 import {PIN_CODE_LENGTH} from '../../@config/constants';
-import {setBiometrics} from '../../store/actions/user.actions';
 import {
   SSIBasicHorizontalCenterContainerStyled as Container,
   SSILockScreenPinCodeContainerStyled as PinCodeContainer,
   SSIStatusBarDarkModeStyled as StatusBar,
 } from '../../styles/components';
 import {ScreenRoutesEnum, StackParamList} from '../../types';
-import {useAuthEffect} from '../../hooks/use-biometrics';
-import {Platform} from 'react-native';
-import {useDispatch} from 'react-redux';
-import {OnboardingBiometricsStatus} from '../../types/machines/onboarding';
+import {useAuthEffect, useAuthFocusEffect, useBiometricsEnabledContext} from '../../hooks/use-biometrics';
 
 type Props = NativeStackScreenProps<StackParamList, ScreenRoutesEnum.LOCK>;
 
@@ -29,10 +25,21 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
     });
   }, []);
 
-  const dispatch = useDispatch();
+  const biometricsEnabled = useBiometricsEnabledContext();
 
-  useAuthEffect(async (success: boolean) => {
+  // useAuthEffect(async (success: boolean) => {
+  //   console.log('effect');
+  //   if (success) {
+  //     console.log('found success');
+  //     const {onAuthenticate} = props.route.params;
+  //     await onAuthenticate();
+  //   }
+  // });
+
+  useAuthFocusEffect(async (success: boolean) => {
+    console.log('effect');
     if (success) {
+      console.log('found success');
       const {onAuthenticate} = props.route.params;
       await onAuthenticate();
     }
@@ -56,13 +63,15 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
     <Container>
       <StatusBar />
       <PinCodeContainer>
-        <SSIPinCode
-          length={PIN_CODE_LENGTH}
-          accessibilityLabel={translate('pin_code_accessibility_label')}
-          accessibilityHint={translate('pin_code_accessibility_hint')}
-          errorMessage={translate('pin_code_invalid_code_message')}
-          onVerification={onVerification}
-        />
+        {!biometricsEnabled && (
+          <SSIPinCode
+            length={PIN_CODE_LENGTH}
+            accessibilityLabel={translate('pin_code_accessibility_label')}
+            accessibilityHint={translate('pin_code_accessibility_hint')}
+            errorMessage={translate('pin_code_invalid_code_message')}
+            onVerification={onVerification}
+          />
+        )}
       </PinCodeContainer>
       {/*<BadgeButton*/}
       {/*  caption={translate('lock_emergency_button_caption')}*/}

--- a/src/screens/SSILockScreen/index.tsx
+++ b/src/screens/SSILockScreen/index.tsx
@@ -55,15 +55,13 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
     <Container>
       <StatusBar />
       <PinCodeContainer>
-        {!biometricsEnabled && (
-          <SSIPinCode
-            length={PIN_CODE_LENGTH}
-            accessibilityLabel={translate('pin_code_accessibility_label')}
-            accessibilityHint={translate('pin_code_accessibility_hint')}
-            errorMessage={translate('pin_code_invalid_code_message')}
-            onVerification={onVerification}
-          />
-        )}
+        <SSIPinCode
+          length={PIN_CODE_LENGTH}
+          accessibilityLabel={translate('pin_code_accessibility_label')}
+          accessibilityHint={translate('pin_code_accessibility_hint')}
+          errorMessage={translate('pin_code_invalid_code_message')}
+          onVerification={onVerification}
+        />
       </PinCodeContainer>
       {/*<BadgeButton*/}
       {/*  caption={translate('lock_emergency_button_caption')}*/}

--- a/src/screens/SSILockScreen/index.tsx
+++ b/src/screens/SSILockScreen/index.tsx
@@ -27,9 +27,7 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
   }, []);
 
   useAuthFocusEffect(async (success: boolean) => {
-    const lockingHandler = LockingHandler.getInstance();
     if (success) {
-      lockingHandler.touchLastInteraction();
       const {onAuthenticate} = props.route.params;
       await onAuthenticate();
     }

--- a/src/screens/SSILockScreen/index.tsx
+++ b/src/screens/SSILockScreen/index.tsx
@@ -12,7 +12,7 @@ import {
   SSIStatusBarDarkModeStyled as StatusBar,
 } from '../../styles/components';
 import {ScreenRoutesEnum, StackParamList} from '../../types';
-import {useAuthFocusEffect, useBiometricsEnabledContext} from '../../hooks/use-biometrics';
+import {useAuthFocusEffect} from '../../hooks/use-biometrics';
 import LockingHandler from 'src/handlers/LockingHandler';
 
 type Props = NativeStackScreenProps<StackParamList, ScreenRoutesEnum.LOCK>;
@@ -25,8 +25,6 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
       void changeNavigationBarColor(backgroundColors.primaryDark);
     });
   }, []);
-
-  const biometricsEnabled = useBiometricsEnabledContext();
 
   useAuthFocusEffect(async (success: boolean) => {
     const lockingHandler = LockingHandler.getInstance();

--- a/src/screens/SSILockScreen/index.tsx
+++ b/src/screens/SSILockScreen/index.tsx
@@ -12,7 +12,8 @@ import {
   SSIStatusBarDarkModeStyled as StatusBar,
 } from '../../styles/components';
 import {ScreenRoutesEnum, StackParamList} from '../../types';
-import {useAuthEffect, useAuthFocusEffect, useBiometricsEnabledContext} from '../../hooks/use-biometrics';
+import {useAuthFocusEffect, useBiometricsEnabledContext} from '../../hooks/use-biometrics';
+import LockingHandler from 'src/handlers/LockingHandler';
 
 type Props = NativeStackScreenProps<StackParamList, ScreenRoutesEnum.LOCK>;
 
@@ -27,19 +28,10 @@ const SSILockScreen: FC<Props> = (props: Props): JSX.Element => {
 
   const biometricsEnabled = useBiometricsEnabledContext();
 
-  // useAuthEffect(async (success: boolean) => {
-  //   console.log('effect');
-  //   if (success) {
-  //     console.log('found success');
-  //     const {onAuthenticate} = props.route.params;
-  //     await onAuthenticate();
-  //   }
-  // });
-
   useAuthFocusEffect(async (success: boolean) => {
-    console.log('effect');
+    const lockingHandler = LockingHandler.getInstance();
     if (success) {
-      console.log('found success');
+      lockingHandler.touchLastInteraction();
       const {onAuthenticate} = props.route.params;
       await onAuthenticate();
     }

--- a/src/store/actions/user.actions.ts
+++ b/src/store/actions/user.actions.ts
@@ -125,6 +125,7 @@ export const login = (userId: string): ThunkAction<Promise<void>, RootState, unk
         const user = users.get(userId);
         if (user) {
           dispatch({type: LOGIN_SET_ACTIVE_USER, payload: user});
+          //unlocking immediately to prevent re-locking after login
           lockingHandler.isLocked = false;
 
           // We do we need to use the while loop here? The above is a sync action that does not use a thunk, thus getState().user should be available already

--- a/src/store/actions/user.actions.ts
+++ b/src/store/actions/user.actions.ts
@@ -121,9 +121,11 @@ export const login = (userId: string): ThunkAction<Promise<void>, RootState, unk
     dispatch({type: USERS_LOADING});
     await userServiceGetUsers()
       .then(async (users: Map<string, IUser>) => {
+        const lockingHandler = LockingHandler.getInstance();
         const user = users.get(userId);
         if (user) {
           dispatch({type: LOGIN_SET_ACTIVE_USER, payload: user});
+          lockingHandler.isLocked = false;
 
           // We do we need to use the while loop here? The above is a sync action that does not use a thunk, thus getState().user should be available already
           const maxWaitTime = 5000;
@@ -144,9 +146,7 @@ export const login = (userId: string): ThunkAction<Promise<void>, RootState, unk
           await dispatch(getVerifiableCredentials());
           // add small delay to make the conditional navigation working for the catalog
           await delay(700);
-          const lockingHandler = await LockingHandler.getInstance();
           lockingHandler.touchLastInteraction();
-          lockingHandler.isLocked = false;
 
           dispatch({type: LOGIN_SUCCESS});
           const intentHandler = IntentHandler.getInstance();


### PR DESCRIPTION
- added a duplicate hook for auth effects tied to navigation focus
- added os specific conditions to the locking handler
- added locking handler touch to biometrics effect, removed logs

This PR addressed MWALL-711, as well as some other issues introduced by a previous change to the locking handler. 

- Previous locking handler changes forced the wallet to always lock when going into background. This introduced side effects on both android and ios when briefly navigating to other apps during separate flows. Said changes were a workaround to avoid biometrics issues on ios. This pr reverts some of those changes. 
- This pr also moves the timing of the unlock command during logins so that ios does not relock immediately after logging in with biometrics. which is a different workaround for the changes that are being reverted.
- this pr thus also removes the side effects for android that were introduced as well.
- additionally this pr removes the strong biometrics enrolment alert on the EnableBiometricsScreen.
- This pr also prevents the keyboard from showing on the lock screen when biometrics is enabled. This is meant to prevent the side effect of the keyboard popping up between successful biometrics and login. but needs to be tested by another device.
